### PR TITLE
Update Pulumi SDK to reflect API's required CT arguments.

### DIFF
--- a/sdk/nodejs/ct/container.ts
+++ b/sdk/nodejs/ct/container.ts
@@ -239,7 +239,7 @@ export interface ContainerArgs {
     /**
      * The network interfaces
      */
-    networkInterfaces?: pulumi.Input<pulumi.Input<inputs.CT.ContainerNetworkInterface>[]>;
+    networkInterfaces: pulumi.Input<pulumi.Input<inputs.CT.ContainerNetworkInterface>[]>;
     /**
      * The node name
      */
@@ -247,7 +247,7 @@ export interface ContainerArgs {
     /**
      * The operating system configuration
      */
-    operatingSystem?: pulumi.Input<inputs.CT.ContainerOperatingSystem>;
+    operatingSystem: pulumi.Input<inputs.CT.ContainerOperatingSystem>;
     /**
      * The ID of the pool to assign the container to
      */
@@ -263,5 +263,5 @@ export interface ContainerArgs {
     /**
      * The VM identifier
      */
-    vmId?: pulumi.Input<number>;
+    vmId: pulumi.Input<number>;
 }


### PR DESCRIPTION
According to [the Proxmox API viewer](https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/lxc), the API requires `vmid`, `node`, and `ostemplate`. However, from experience, this alone is not enough. It will still complain if you don't supply at least one network interface, so I made that required too.

Unfortunately, I don't have much experience with 2/4 languages, so I only applied this to NodeJS and Python:

- [x] NodeJS
- [x] Python
- [ ] .NET
- [ ] Go