### PR TITLE
fix python example

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -160,68 +160,67 @@ const virtualMachine = new proxmox.vm.VirtualMachine('vm', {
 ```python
 import pulumi_proxmoxve as proxmox
 
-virtual_machine = proxmox.vm.VirtualMachine("vm",
+virtual_machine = proxmox.vm.VirtualMachine(
+    resource_name="vm",
     node_name="pve1",
-    agent=VirtualMachineAgentArgs(
-        enabled=False, // toggles checking for ip addresses through qemu-guest-agent
+    agent=proxmox.vm.VirtualMachineAgentArgs(
+        enabled=False, # toggles checking for ip addresses through qemu-guest-agent
         trim=True,
         type="virtio"
     ),
     bios="seabios",
-    cpu=VirtualMachineCpuArgs(
+    cpu=proxmox.vm.VirtualMachineCpuArgs(
         cores=1,
         sockets=1
     ),
-    clone=VirtualMachineCloneArgs(
+    clone=proxmox.vm.VirtualMachineCloneArgs(
         node_name="pve1",
         vm_id=9000,
         full=True
     ),
     disks=[
-        VirtualMachineDiskArgs(
+        proxmox.vm.VirtualMachineDiskArgs(
             interface="scsi0",
             datastore_id="local-lvm",
             size=32,
             file_format="qcow2"
         )
     ],
-    memory=VirtualMachineMemoryArgs(
+    memory=proxmox.vm.VirtualMachineMemoryArgs(
         dedicated=1024
     ),
     name="proxmox-vm",
     network_devices=[
-        VirtualMachineNetworkDeviceArgs(
+        proxmox.vm.VirtualMachineNetworkDeviceArgs(
             bridge="vmbr0",
             model="virtio"
         )
     ],
-    on_boot: True,
-    operating_system: VirtualMachineOperatingSystemArgs(
-        type: "l26"
-    ),
-    initialization=VirtualMachineInitializationArgs(
+    on_boot=True,
+    operating_system=proxmox.vm.VirtualMachineOperatingSystemArgs(type="l26"),
+    initialization=proxmox.vm.VirtualMachineInitializationArgs(
         type="nocloud",
         datastore_id="local-lvm",
-        dns=VirtualMachineInitializationDnsArgs(
+        dns=proxmox.vm.VirtualMachineInitializationDnsArgs(
             domain="example.com",
             server="1.1.1.1 1.0.0.1"
         ),
-        ip_configs: [
-            VirtualMachineInitializationIpConfigArgs(
-                ipv4=VirtualMachineInitializationIpConfigIpv4Args(
+        ip_configs=[
+            proxmox.vm.VirtualMachineInitializationIpConfigArgs(
+                ipv4=proxmox.vm.VirtualMachineInitializationIpConfigIpv4Args(
                     address="10.0.0.10/24",
                     gateway="10.0.0.1"
                 ),
-                ipv6=VirtualMachineInitializationIpConfigIpv6Args(
+                ipv6=proxmox.vm.VirtualMachineInitializationIpConfigIpv6Args(
                     address="fd91:0812:a17f:6194::10/64",
                     gateway="fd91:0812:a17f:6194::1"
                 )
             )
         ],
-        user_account=VirtualMachineInitializationUserAccountArgs(
-            username: "proxmox",
-            password: "password",
-            keys: ["SSH_PUBLIC_KEY"]
+        user_account=proxmox.vm.VirtualMachineInitializationUserAccountArgs(
+            username="proxmox",
+            password="password",
+            keys=["SSH_PUBLIC_KEY"]
         )
     )
 )


### PR DESCRIPTION
while copy pasting the python example on the proxmox example from the website we get several errors. This PR aims to fix those errors.

    usage of : instead of =
    comment // instead of #
    import fixing